### PR TITLE
EIP-45: Importing AppConfig and setting debezium.snapshotLockingMode=extended.

### DIFF
--- a/app/src/main/resources/config/application.properties
+++ b/app/src/main/resources/config/application.properties
@@ -22,4 +22,5 @@ debezium-event-reader.repeat.interval=100
 # the database, while the connector is performing a snapshot
 # https://debezium.io/documentation/reference/connectors/mysql.html#mysql-property-snapshot-locking-mode
 debezium.snapshotLockingMode=extended
+
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR will fix runtime exceptions due to missing application configs brought in by the [openmrs-eip](https://github.com/openmrs/openmrs-eip). See docs [here](https://github.com/openmrs/openmrs-eip/blob/master/docs/custom/README.md).