### PR TITLE
C2C-138: Docker image to work on ARM processors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_dispatch:
 
 jobs:
-  build_and_deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v2
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -38,51 +37,29 @@ jobs:
         if: github.ref == 'refs/heads/main'
         run: mv app/target/*.jar docker/
 
-      - name: Start custom Docker builders (ARM & AMD) with Terraform
-        if: github.ref == 'refs/heads/main'
-        run: |
-          export TF_VAR_aws_api_key='${{ secrets.AWS_API_KEY_1 }}'
-          export TF_VAR_aws_api_secret='${{ secrets.AWS_API_SECRET_1 }}'
-          ./.github/resources/scripts/start_terraform.sh
-
-      - name: Set new AWS instances private key
-        if: github.ref == 'refs/heads/main'
-        run: |
-          echo "⚙️ Set AWS AMI private key."
-          AWS_AMI_PRIVATE_KEY_FILE=$(mktemp)
-          echo "${{ secrets.AWS_AMI_PRIVATE_KEY }}" > $AWS_AMI_PRIVATE_KEY_FILE
-          chmod 600 $AWS_AMI_PRIVATE_KEY_FILE
-          echo "AWS_AMI_PRIVATE_KEY_FILE=$AWS_AMI_PRIVATE_KEY_FILE" >> $GITHUB_ENV
-
-      - name: Wait for 60s
-        if: github.ref == 'refs/heads/main'
-        run: sleep 60s
-
-      - name: Copy files
-        if: github.ref == 'refs/heads/main'
-        run: |
-          ./.github/resources/scripts/copy_files.sh
-
-      - name: Build Docker images on remote instances
-        if: github.ref == 'refs/heads/main'
-        run: |
-          ./.github/resources/scripts/build_images.sh
-
-      - name: Push images on Docker Hub
-        if: github.ref == 'refs/heads/main'
-        run: |
-          export DOCKER_PASSWORD=${{ secrets.DOCKER_HUB_REGISTRY_PASSWORD }}
-          ./.github/resources/scripts/push_images.sh
-
-      - name: Push tags on Docker Hub
-        if: github.ref == 'refs/heads/main'
-        run: |
-          export DOCKER_PASSWORD=${{ secrets.DOCKER_HUB_REGISTRY_PASSWORD }}
-          ./.github/resources/scripts/push_tags.sh
-
-      - name: Destroy Terraform infrastructure
-        if: ${{ always() }}
-        run: |
-          export TF_VAR_aws_api_key='${{ secrets.AWS_API_KEY_1 }}'
-          export TF_VAR_aws_api_secret='${{ secrets.AWS_API_SECRET_1 }}'
-          ./.github/resources/scripts/destroy_terraform.sh
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_HUB_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_REGISTRY_PASSWORD }}
+      - 
+        name: Get commit id
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        env: 
+          SERVICE: eip-client
+        with:
+          context: ./docker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_REGISTRY_USERNAME }}/${{ env.SERVICE }}:latest,${{ secrets.DOCKER_HUB_REGISTRY_USERNAME }}/${{ env.SERVICE }}:${{ steps.vars.outputs.sha_short }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .springBeans
 .sts4-cache
 *.DS_Store
+.vscode/
 
 
 # Created by https://www.gitignore.io/api/git,java,maven,eclipse,windows

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: mvn clean package

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-focal
 RUN mkdir /config
 RUN mkdir /routes
 RUN mkdir /eip-home
-RUN apk add gettext --no-cache
+RUN apt-get update && apt install -y gettext netcat
 COPY run.sh run.sh
 COPY wait-for.sh wait-for.sh
 RUN chmod +x run.sh wait-for.sh


### PR DESCRIPTION
- Image is not based on **alpine** anymore
- Github workflow doesn't use **terraform** to build images and push them but use **github actions**
- Using **eclipse-temurin** jdk image base since **adoptopenjdk** is deprecated