### PR TITLE
OZ-546: Move monitoring dependencies to `eip-commons`.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -34,24 +34,6 @@
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${spring-boot.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.camel.springboot</groupId>
-      <artifactId>camel-micrometer-starter</artifactId>
-      <version>${camel.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.ozonehis</groupId>
       <artifactId>eip-commons</artifactId>
       <version>${project.version}</version>

--- a/app/src/main/resources/eip-client.properties
+++ b/app/src/main/resources/eip-client.properties
@@ -7,7 +7,6 @@ spring.jpa.open-in-view=false
 # ----------------------------------------------------------------------------------------------------------------------
 
 ## --- Monitoring Configuration ------------------------------------------------------------------------------------------
-management.endpoints.web.exposure.include=*
 management.endpoints.web.exposure.include=prometheus,health,info,metric
 
 management.health.probes.enabled=true

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -40,11 +40,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-actuator</artifactId>
-      <version>${spring-boot.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-artemis</artifactId>
       <version>${spring-boot.version}</version>
     </dependency>
@@ -165,10 +160,30 @@
           <artifactId>slf4j-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>ch.qos.reload4j</groupId>
-          <artifactId>reload4j</artifactId>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-reload4j</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- Monitoring -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${spring-boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel.springboot</groupId>
+      <artifactId>camel-micrometer-starter</artifactId>
+      <version>${camel.version}</version>
     </dependency>
 
     <!-- Tests -->


### PR DESCRIPTION
This PR addresses the need to centralize the monitoring dependencies in the `eip-commons` sub-module.

This change will allow `eip-pro-client` to inherit these dependencies directly from `eip-commons`, ensuring that all both projects have a consistent set of monitoring dependencies. This also simplifies the management of these dependencies, as updates or changes will only need to be made in one place.