### PR TITLE
OZ-657: Silence error caused by missing `eip.app.scan.packages` property.

### DIFF
--- a/app/src/main/java/com/ozonehis/eip/Application.java
+++ b/app/src/main/java/com/ozonehis/eip/Application.java
@@ -12,7 +12,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @Slf4j
-@SpringBootApplication(scanBasePackages = "com.ozonehis.eip.*, ${eip.app.scan.packages}")
+@SpringBootApplication(scanBasePackages = "com.ozonehis.eip.*, ${eip.app.scan.packages:}")
 public class Application {
 
     public static void main(final String[] args) {


### PR DESCRIPTION
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-657

To prevent unintended interruptions that would result from reverting https://github.com/ozone-his/eip-client/pull/37, I'm creating this PR resolve errors on development servers and unblock users trying out the Ozone project.