### PR TITLE
Remove deprecated version from Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-version: '3'
 services:
   eip-client:
     container_name: ozone-eip-client


### PR DESCRIPTION
This PR makes a small change to the `docker-compose.yml` file, removing the `version: '3'` line. This simplifies the file and relies on the default Compose file version, which is supported in recent versions of Docker Compose.